### PR TITLE
Account for newly-added entry in the rows of _assetmanifest files

### DIFF
--- a/src/manifests/asset_manifest.py
+++ b/src/manifests/asset_manifest.py
@@ -14,7 +14,7 @@ class AssetManifest(AbstractManifest[Manifest]):
             rows = f.readlines()
         files = []
         for row in rows:
-            path, hash_, _, size, *_ = row.split(",")
+            path, hash_, _, evertutocom, size, *_ = row.split(",")
             manifest = Manifest(
                 path, hash_, self.version, ManifestType.ASSET, int(size)
             )

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -27,6 +27,6 @@ class Manifest(
             rows = f.readlines()
         files = []
         for row in rows:
-            path, hash_, _, size, *_ = row.split(",")
+            path, hash_, _, evertutocom, size, *_ = row.split(",")
             files.append(AssetBundle(path, hash_, int(size)))
         return files

--- a/src/manifests/movie_manifest.py
+++ b/src/manifests/movie_manifest.py
@@ -15,7 +15,7 @@ class MovieManifest(AbstractManifest[MovieFile]):
             rows = f.readlines()
         files: list[MovieFile] = []
         for row in rows:
-            path, hash_, _, size, *_ = row.split(",")
+            path, hash_, _, evertutocom, size, *_ = row.split(",")
             new_path = Path(path)
             files.append(
                 MovieFile(

--- a/src/manifests/sound_manifest.py
+++ b/src/manifests/sound_manifest.py
@@ -15,7 +15,7 @@ class SoundManifest(AbstractManifest[SoundFile]):
             rows = f.readlines()
         files: list[SoundFile] = []
         for row in rows:
-            path, hash_, _, size, *_ = row.split(",")
+            path, hash_, _, evertutocom, size, *_ = row.split(",")
             new_path: Path = Path(path)
             files.append(
                 SoundFile(


### PR DESCRIPTION
I've found that the extractor is failing when it tries to assign a specific entry from any asset manifest's rows to a size variable. This worked fine in the past, but a recent update to Priconne's manifest row format added a new entry before that of the byte size, causing the extractor to throw the following error:
![pic](https://github.com/lskyset/priconne-asset-extractor/assets/47084488/8e9bebcc-7b1f-4d97-88ea-74491e2cc75e)

I've added a new allocation to the manifest scripts (the \src\manifests\ ones that assign each row's entries to something else). I've dubbed the entry "evertutocom" since the _assetmanifest files either use 'every', 'tutorial0/1', or 'common', but it could really be anything you want.